### PR TITLE
Fixing block-buffer dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ml-kem = "0.2.1"
 kem = "0.3.0-pre.0"
 sha2 = "0.11.0-pre.4"
 thiserror = "1"
+block-buffer = "=0.11.0-rc.3"
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(test), deny(unsafe_code))]
 #![warn(clippy::doc_markdown, missing_docs, rustdoc::all)]
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod errors;
 mod messages;


### PR DESCRIPTION
Unfortunately, block-buffer v0.11.0-rc.4 causes issues with the compilation of this library, so we are pinning to:
```
block-buffer = "=0.11.0-rc.3"
```
in the Cargo.toml.