### PR TITLE
Upgrade ml-kem to v0.3.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.0-pre.6 (March 26, 2026)
+
+* Upgrade `ml-kem` to v0.3.0-rc.0
+* Upgrade `rand_core` to v0.10, `curve25519-dalek` to v5.0.0-pre.6, `hkdf` to v0.13.0-rc.5, `sha2` to v0.11.0-pre.4
+* Replace `OsRng` with `UnwrapErr(getrandom::SysRng)` for `rand_core` 0.10 compatibility
+* Make `EncodedSizeUser::from_bytes` fallible (returns `Result<Self, PakeKemError>`)
+* Remove dummy-key fallback on deserialization failure in `MessageTwo` and `Responder`
+* Define local `EncodedSizeUser` trait (no longer re-exported from `ml-kem`)
+* Fix pre-existing clippy `doc_markdown` warning
+
 ## 0.1.0-pre.1 (October 10, 2024)
 
 * Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,26 @@
 [package]
 name = "pake-kem"
 description = "An implementation of a password-authenticated key exchange (PAKE) based from a key encapsulation mechanism (KEM)."
-version = "0.1.0-pre.5"
+version = "0.1.0-pre.6"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/facebook/pake-kem"
 categories = ["cryptography"]
 keywords = ["cryptography"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-curve25519-dalek = { version = "4", features = ["rand_core"] }
-hkdf = { version = "0.13.0-pre.4", features = ["std"] }
-rand_core = { version = "0.6", features = ["getrandom"] }
-ml-kem = "0.2.1"
-kem = "0.3.0-pre.0"
+curve25519-dalek = { version = "=5.0.0-pre.6", features = ["rand_core"] }
+hkdf = "=0.13.0-rc.5"
+rand_core = { version = "0.10", default-features = false }
+ml-kem = "0.3.0-rc.0"
 sha2 = "0.11.0-pre.4"
 thiserror = "1"
-block-buffer = "=0.11.0-rc.3"
+getrandom = { version = "0.4", features = ["sys_rng"] }
 
 [dev-dependencies]
 hex = "0.4"
 serde_json = "1"
 base64 = "0.22"
-
-# wasm stuff
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 Add the following line to the dependencies of your `Cargo.toml`:
 
 ```
-pake-kem = "0.1.0-pre.5"
+pake-kem = "0.1.0-pre.6"
 ```
 
 Threat model

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,9 +6,9 @@
 // of this source tree. You may select, at your option, one of the above-listed
 // licenses.
 
-use ml_kem::EncodedSizeUser;
-use pake_kem::rand_core::OsRng;
+use pake_kem::rand_core::UnwrapErr;
 use pake_kem::DefaultCipherSuite;
+use pake_kem::EncodedSizeUser;
 use pake_kem::Initiator;
 use pake_kem::Input;
 use pake_kem::MessageOne;
@@ -19,8 +19,8 @@ use pake_kem::Responder;
 fn main() {
     let input = Input::new(b"password", b"initiator", b"responder");
 
-    let mut initiator_rng = OsRng;
-    let mut responder_rng = OsRng;
+    let mut initiator_rng = UnwrapErr(getrandom::SysRng);
+    let mut responder_rng = UnwrapErr(getrandom::SysRng);
 
     let (initiator, message_one) =
         Initiator::<DefaultCipherSuite>::start(&input, &mut initiator_rng)
@@ -39,7 +39,8 @@ fn main() {
         message_one_serialized.len(),
         hex::encode(message_one_serialized)
     );
-    let message_one_deserialized = MessageOne::from_bytes(&message_one_serialized);
+    let message_one_deserialized =
+        MessageOne::from_bytes(&message_one_serialized).expect("Failed to deserialize MessageOne");
 
     let (responder, message_two) = Responder::<DefaultCipherSuite>::start(
         &input,
@@ -60,9 +61,11 @@ fn main() {
         message_two_serialized.len(),
         hex::encode(message_two_serialized)
     );
-    let message_two_deserialized = MessageTwo::from_bytes(&message_two_serialized);
+    let message_two_deserialized =
+        MessageTwo::from_bytes(&message_two_serialized).expect("Failed to deserialize MessageTwo");
 
-    let initiator = Initiator::<DefaultCipherSuite>::from_bytes(&initiator_serialized);
+    let initiator = Initiator::<DefaultCipherSuite>::from_bytes(&initiator_serialized)
+        .expect("Failed to deserialize Initiator");
     let (initiator_output, message_three) = initiator
         .finish(&message_two_deserialized, &mut initiator_rng)
         .expect("Error with Initiator::finish()");
@@ -73,9 +76,11 @@ fn main() {
         message_three_serialized.len(),
         hex::encode(message_three_serialized)
     );
-    let message_three_deserialized = MessageThree::from_bytes(&message_three_serialized);
+    let message_three_deserialized = MessageThree::from_bytes(&message_three_serialized)
+        .expect("Failed to deserialize MessageThree");
 
     let responder_output = Responder::<DefaultCipherSuite>::from_bytes(&responder_serialized)
+        .expect("Failed to deserialize Responder")
         .finish(&message_three_deserialized)
         .expect("Error with Responder::finish()");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,9 @@
 //! # let input = Input::new(b"password", b"initiator", b"responder");
 //! use pake_kem::EncodedSizeUser; // Needed for calling as_bytes()
 //! use pake_kem::Initiator;
-//! use rand_core::OsRng;
+//! use rand_core::UnwrapErr;
 //!
-//! let mut initiator_rng = OsRng;
+//! let mut initiator_rng = UnwrapErr(getrandom::SysRng);
 //! let (initiator, message_one) = Initiator::<DefaultCipherSuite>::start(&input, &mut initiator_rng)
 //!    .expect("Error with Initiator::start()");
 //! let message_one_bytes = message_one.as_bytes();
@@ -112,9 +112,9 @@
 //! # let input = Input::new(b"password", b"initiator", b"responder");
 //! # use pake_kem::EncodedSizeUser; // Needed for calling as_bytes()
 //! # use pake_kem::Initiator;
-//! # use rand_core::OsRng;
+//! # use rand_core::UnwrapErr;
 //! #
-//! # let mut initiator_rng = OsRng;
+//! # let mut initiator_rng = UnwrapErr(getrandom::SysRng);
 //! # let (initiator, message_one) = Initiator::<DefaultCipherSuite>::start(&input, &mut initiator_rng)
 //! #    .expect("Error with Initiator::start()");
 //! # let message_one_bytes = message_one.as_bytes();
@@ -122,8 +122,8 @@
 //! use pake_kem::MessageOne;
 //! use pake_kem::Responder;
 //!
-//! let mut responder_rng = OsRng;
-//! let message_one = MessageOne::from_bytes(&message_one_bytes);
+//! let mut responder_rng = UnwrapErr(getrandom::SysRng);
+//! let message_one = MessageOne::from_bytes(&message_one_bytes).expect("deserialization failed");
 //! let (responder, message_two) =
 //!     Responder::<DefaultCipherSuite>::start(&input, &message_one, &mut responder_rng)
 //!        .expect("Error with Responder::start()");
@@ -152,9 +152,9 @@
 //! # let input = Input::new(b"password", b"initiator", b"responder");
 //! # use pake_kem::EncodedSizeUser; // Needed for calling as_bytes()
 //! # use pake_kem::Initiator;
-//! # use rand_core::OsRng;
+//! # use rand_core::UnwrapErr;
 //! #
-//! # let mut initiator_rng = OsRng;
+//! # let mut initiator_rng = UnwrapErr(getrandom::SysRng);
 //! # let (initiator, message_one) = Initiator::<DefaultCipherSuite>::start(&input, &mut initiator_rng)
 //! #    .expect("Error with Initiator::start()");
 //! # let message_one_bytes = message_one.as_bytes();
@@ -162,8 +162,8 @@
 //! # use pake_kem::MessageOne;
 //! # use pake_kem::Responder;
 //! #
-//! # let mut responder_rng = OsRng;
-//! # let message_one = MessageOne::from_bytes(&message_one_bytes);
+//! # let mut responder_rng = UnwrapErr(getrandom::SysRng);
+//! # let message_one = MessageOne::from_bytes(&message_one_bytes).expect("deserialization failed");
 //! # let (responder, message_two) =
 //! #     Responder::<DefaultCipherSuite>::start(&input, &message_one, &mut responder_rng)
 //! #        .expect("Error with Responder::start()");
@@ -171,7 +171,7 @@
 //! # // Send message_two_bytes over the wire to the initiator
 //! use pake_kem::MessageTwo;
 //!
-//! let message_two = MessageTwo::from_bytes(&message_two_bytes);
+//! let message_two = MessageTwo::from_bytes(&message_two_bytes).expect("deserialization failed");
 //! let (initiator_output, message_three) =
 //!     initiator.finish(&message_two, &mut initiator_rng)
 //!         .expect("Error with Initiator::finish()");
@@ -200,9 +200,9 @@
 //! # let input = Input::new(b"password", b"initiator", b"responder");
 //! # use pake_kem::EncodedSizeUser; // Needed for calling as_bytes()
 //! # use pake_kem::Initiator;
-//! # use rand_core::OsRng;
+//! # use rand_core::UnwrapErr;
 //! #
-//! # let mut initiator_rng = OsRng;
+//! # let mut initiator_rng = UnwrapErr(getrandom::SysRng);
 //! # let (initiator, message_one) = Initiator::<DefaultCipherSuite>::start(&input, &mut initiator_rng)
 //! #    .expect("Error with Initiator::start()");
 //! # let message_one_bytes = message_one.as_bytes();
@@ -210,8 +210,8 @@
 //! # use pake_kem::MessageOne;
 //! # use pake_kem::Responder;
 //! #
-//! # let mut responder_rng = OsRng;
-//! # let message_one = MessageOne::from_bytes(&message_one_bytes);
+//! # let mut responder_rng = UnwrapErr(getrandom::SysRng);
+//! # let message_one = MessageOne::from_bytes(&message_one_bytes).expect("deserialization failed");
 //! # let (responder, message_two) =
 //! #     Responder::<DefaultCipherSuite>::start(&input, &message_one, &mut responder_rng)
 //! #        .expect("Error with Responder::start()");
@@ -219,7 +219,7 @@
 //! # // Send message_two_bytes over the wire to the initiator
 //! # use pake_kem::MessageTwo;
 //! #
-//! # let message_two = MessageTwo::from_bytes(&message_two_bytes);
+//! # let message_two = MessageTwo::from_bytes(&message_two_bytes).expect("deserialization failed");
 //! # let (initiator_output, message_three) =
 //! #     initiator.finish(&message_two, &mut initiator_rng)
 //! #         .expect("Error with Initiator::finish()");
@@ -227,7 +227,7 @@
 //! # // Send message_three_bytes over the wire to the responder
 //! use pake_kem::MessageThree;
 //!
-//! let message_three = MessageThree::from_bytes(&message_three_bytes);
+//! let message_three = MessageThree::from_bytes(&message_three_bytes).expect("deserialization failed");
 //! let responder_output = responder.finish(&message_three)
 //!    .expect("Error with Responder::finish()");
 //! ```
@@ -253,9 +253,26 @@ pub use pake::CPaceRistretto255;
 pub use protocol::{CipherSuite, DefaultCipherSuite, Initiator, Input, Output, Responder};
 
 // Re-exports
+pub use getrandom;
 pub use hkdf::hmac::digest::array::Array;
-pub use ml_kem::EncodedSizeUser;
 pub use rand_core;
+
+use ml_kem::array::{Array as MlKemArray, ArraySize};
+
+/// Type alias for the encoded form of a type implementing [`EncodedSizeUser`].
+pub type Encoded<T> = MlKemArray<u8, <T as EncodedSizeUser>::EncodedSize>;
+
+/// Trait for types that can be serialized to/from a fixed-size byte array.
+pub trait EncodedSizeUser {
+    /// The size of the encoded form.
+    type EncodedSize: ArraySize;
+    /// Serialize to bytes.
+    fn as_bytes(&self) -> Encoded<Self>;
+    /// Deserialize from bytes.
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, crate::PakeKemError>
+    where
+        Self: Sized;
+}
 
 #[cfg(test)]
 mod tests;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -9,17 +9,15 @@
 //! The messages used in the pake-kem protocol
 
 use crate::pake::Pake;
-use crate::CipherSuite;
+use crate::{CipherSuite, Encoded, EncodedSizeUser, PakeKemError};
 use core::ops::{Add, Sub};
 use hkdf::hmac::digest::array::Array;
 use hkdf::hmac::digest::typenum::Sum;
 use hkdf::hmac::digest::OutputSizeUser;
 use hkdf::hmac::EagerHash;
-use ml_kem::ArraySize;
-use ml_kem::Ciphertext;
-use ml_kem::Encoded;
-use ml_kem::EncodedSizeUser;
-use ml_kem::KemCore;
+use ml_kem::array::ArraySize;
+use ml_kem::kem::{FromSeed, KeySizeUser};
+use ml_kem::{Ciphertext, Kem, KeyExport, TryKeyInit};
 
 /// The first message in the pake-kem protocol, created by the initiator
 #[derive(Debug)]
@@ -30,10 +28,10 @@ pub struct MessageOne<CS: CipherSuite> {
 impl<CS: CipherSuite> EncodedSizeUser for MessageOne<CS> {
     type EncodedSize = <<CS::Pake as Pake>::InitMessage as EncodedSizeUser>::EncodedSize;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
-        Self {
-            init_message: <CS::Pake as Pake>::InitMessage::from_bytes(enc),
-        }
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
+        Ok(Self {
+            init_message: <CS::Pake as Pake>::InitMessage::from_bytes(enc)?,
+        })
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -45,35 +43,37 @@ impl<CS: CipherSuite> EncodedSizeUser for MessageOne<CS> {
 #[derive(Debug)]
 pub struct MessageTwo<CS: CipherSuite> {
     pub(crate) respond_message: <CS::Pake as Pake>::RespondMessage,
-    pub(crate) ek: <CS::Kem as KemCore>::EncapsulationKey,
+    pub(crate) ek: <CS::Kem as Kem>::EncapsulationKey,
     pub(crate) ek_tag: Array<u8, <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize>,
 }
 
 impl<CS: CipherSuite> EncodedSizeUser for MessageTwo<CS>
 where
+    CS::Kem: FromSeed,
+    <CS::Kem as Kem>::EncapsulationKey: KeyExport + TryKeyInit,
     // Concatenation clauses
     <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize:
-        Add<<<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize>,
+        Add<<<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize>,
     Sum<
         <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize,
-        <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+        <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
     >: ArraySize
         + Add<<<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize>
         + Sub<
             <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize,
-            Output = <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            Output = <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
     Sum<
         Sum<
             <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize,
-            <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
         <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
     >: ArraySize
         + Sub<
             Sum<
                 <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize,
-                <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+                <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
             >,
             Output = <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
         >,
@@ -81,25 +81,26 @@ where
     type EncodedSize = Sum<
         Sum<
             <<CS::Pake as Pake>::RespondMessage as EncodedSizeUser>::EncodedSize,
-            <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
         <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
     >;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
         let (enc, ek_tag) = enc.split_ref();
         let (respond_message_bytes, ek_bytes) = enc.split_ref();
-        Self {
-            respond_message: <CS::Pake as Pake>::RespondMessage::from_bytes(respond_message_bytes),
-            ek: <CS::Kem as KemCore>::EncapsulationKey::from_bytes(ek_bytes),
+        Ok(Self {
+            respond_message: <CS::Pake as Pake>::RespondMessage::from_bytes(respond_message_bytes)?,
+            ek: <<CS::Kem as Kem>::EncapsulationKey as TryKeyInit>::new(ek_bytes)
+                .map_err(|_| PakeKemError::Deserialization)?,
             ek_tag: ek_tag.clone(),
-        }
+        })
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
         self.respond_message
             .as_bytes()
-            .concat(self.ek.as_bytes())
+            .concat(KeyExport::to_bytes(&self.ek))
             .concat(self.ek_tag.clone())
     }
 }
@@ -114,28 +115,28 @@ pub struct MessageThree<CS: CipherSuite> {
 impl<CS: CipherSuite> EncodedSizeUser for MessageThree<CS>
 where
     // Concatenation clauses
-    <CS::Kem as KemCore>::CiphertextSize:
+    <CS::Kem as Kem>::CiphertextSize:
         Add<<<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize>,
     Sum<
-        <CS::Kem as KemCore>::CiphertextSize,
+        <CS::Kem as Kem>::CiphertextSize,
         <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
     >: ArraySize
         + Sub<
-            <CS::Kem as KemCore>::CiphertextSize,
+            <CS::Kem as Kem>::CiphertextSize,
             Output = <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
         >,
 {
     type EncodedSize = Sum<
-        <CS::Kem as KemCore>::CiphertextSize,
+        <CS::Kem as Kem>::CiphertextSize,
         <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize,
     >;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
         let (ct, ct_tag) = enc.split_ref();
-        Self {
+        Ok(Self {
             ct: ct.clone(),
             ct_tag: ct_tag.clone(),
-        }
+        })
     }
 
     fn as_bytes(&self) -> Encoded<Self> {

--- a/src/pake/cpace.rs
+++ b/src/pake/cpace.rs
@@ -7,15 +7,14 @@
 // licenses.
 
 use super::*;
-use crate::Array;
+use crate::{Array, Encoded, EncodedSizeUser, PakeKemError};
 use curve25519_dalek::ristretto::CompressedRistretto;
 use curve25519_dalek::ristretto::RistrettoPoint;
 use curve25519_dalek::traits::Identity;
 use curve25519_dalek::Scalar;
 use hkdf::hmac::digest::array::typenum::{U32, U64, U96};
 use hkdf::HkdfExtract;
-use ml_kem::{Encoded, EncodedSizeUser};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use sha2::Digest;
 use sha2::Sha512;
 
@@ -38,8 +37,8 @@ pub struct CPaceRistretto255InitMessage(Array<u8, U32>);
 impl EncodedSizeUser for CPaceRistretto255InitMessage {
     type EncodedSize = U32;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
-        Self(*enc)
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
+        Ok(Self(*enc))
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -53,8 +52,8 @@ pub struct CPaceRistretto255RespondMessage(Array<u8, U32>);
 impl EncodedSizeUser for CPaceRistretto255RespondMessage {
     type EncodedSize = U32;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
-        Self(*enc)
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
+        Ok(Self(*enc))
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -68,8 +67,8 @@ pub struct CPaceRistretto255Output(pub(crate) Array<u8, U96>);
 impl EncodedSizeUser for CPaceRistretto255Output {
     type EncodedSize = U96;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
-        Self(*enc)
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
+        Ok(Self(*enc))
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -80,15 +79,15 @@ impl EncodedSizeUser for CPaceRistretto255Output {
 impl EncodedSizeUser for CPaceRistretto255 {
     type EncodedSize = U64;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
+    fn from_bytes(enc: &Encoded<Self>) -> Result<Self, PakeKemError> {
         let mut arr = [0u8; 32];
         arr.clone_from_slice(&enc[..32]);
         let mut scalar_bytes = [0u8; 32];
         scalar_bytes.clone_from_slice(&enc[32..]);
-        Self {
+        Ok(Self {
             init_message_bytes: arr,
             scalar: Scalar::from_bytes_mod_order(scalar_bytes),
-        }
+        })
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -104,7 +103,7 @@ impl Pake for CPaceRistretto255 {
     type RespondMessage = CPaceRistretto255RespondMessage;
     type Output = CPaceRistretto255Output;
 
-    fn init<R: RngCore + CryptoRng>(input: &Input, rng: &mut R) -> (Self::InitMessage, Self) {
+    fn init<R: CryptoRng>(input: &Input, rng: &mut R) -> (Self::InitMessage, Self) {
         let context = [
             prepend_len(&input.initiator_id),
             prepend_len(&input.responder_id),
@@ -124,7 +123,7 @@ impl Pake for CPaceRistretto255 {
         )
     }
 
-    fn respond<R: RngCore + CryptoRng>(
+    fn respond<R: CryptoRng>(
         input: &Input,
         init_message: &Self::InitMessage,
         rng: &mut R,

--- a/src/pake/mod.rs
+++ b/src/pake/mod.rs
@@ -10,19 +10,19 @@ mod cpace;
 #[cfg(test)]
 mod tests;
 
+use crate::EncodedSizeUser;
 use crate::Input;
 use core::fmt::Debug;
 pub use cpace::CPaceRistretto255;
-use ml_kem::EncodedSizeUser;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 pub trait Pake: EncodedSizeUser {
     type InitMessage: EncodedSizeUser + Debug + PartialEq;
     type RespondMessage: EncodedSizeUser + Debug + PartialEq;
     type Output: EncodedSizeUser + Debug + PartialEq;
 
-    fn init<R: RngCore + CryptoRng>(input: &Input, rng: &mut R) -> (Self::InitMessage, Self);
-    fn respond<R: RngCore + CryptoRng>(
+    fn init<R: CryptoRng>(input: &Input, rng: &mut R) -> (Self::InitMessage, Self);
+    fn respond<R: CryptoRng>(
         input: &Input,
         init_message: &Self::InitMessage,
         rng: &mut R,

--- a/src/pake/tests/cpace_test_vectors.rs
+++ b/src/pake/tests/cpace_test_vectors.rs
@@ -6,7 +6,7 @@
 // of this source tree. You may select, at your option, one of the above-listed
 // licenses.
 
-//! Test vectors for CPace with Ristretto255 and SHA-512,
+//! Test vectors for `CPace` with `Ristretto255` and `SHA-512`,
 //! taken from <https://www.ietf.org/archive/id/draft-irtf-cfrg-cpace-12.txt>
 
 // Taken from A.1.2.1 of the draft.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,21 +12,21 @@ use crate::errors::PakeKemError;
 use crate::messages::{MessageOne, MessageThree, MessageTwo};
 use crate::pake::CPaceRistretto255;
 use crate::pake::Pake;
+use crate::{Encoded, EncodedSizeUser};
 use core::ops::{Add, Sub};
 use hkdf::hmac::digest::array::typenum::U32;
 use hkdf::hmac::digest::array::Array;
-use hkdf::hmac::digest::core_api::BlockSizeUser;
+use hkdf::hmac::digest::block_api::BlockSizeUser;
 use hkdf::hmac::digest::typenum::Sum;
 use hkdf::hmac::digest::FixedOutput;
 use hkdf::hmac::digest::OutputSizeUser;
 use hkdf::hmac::{EagerHash, Hmac, KeyInit, Mac};
 use hkdf::HkdfExtract;
-use kem::{Decapsulate, Encapsulate};
-use ml_kem::ArraySize;
-use ml_kem::Encoded;
-use ml_kem::EncodedSizeUser;
-use ml_kem::KemCore;
-use rand_core::{CryptoRng, RngCore};
+use ml_kem::array::ArraySize;
+use ml_kem::kem::KeySizeUser;
+use ml_kem::kem::TryDecapsulate;
+use ml_kem::{Encapsulate, Kem, KeyExport, TryKeyInit};
+use rand_core::CryptoRng;
 
 type Result<T> = core::result::Result<T, PakeKemError>;
 
@@ -38,7 +38,7 @@ pub trait CipherSuite {
     /// The PAKE protocol to use
     type Pake: Pake;
     /// The key encapsulation mechanism to use
-    type Kem: KemCore;
+    type Kem: Kem;
     /// The hashing function to use
     type Hash: EagerHash + FixedOutput;
 }
@@ -72,7 +72,9 @@ impl Input {
 
 /// The output of the pake-kem protocol
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Output<CS: CipherSuite>(pub Array<u8, <CS::Hash as OutputSizeUser>::OutputSize>);
+pub struct Output<CS: CipherSuite>(
+    pub Array<u8, <<CS::Hash as EagerHash>::Core as OutputSizeUser>::OutputSize>,
+);
 
 /// The main struct for the initiator of the pake-kem protocol
 #[derive(Debug)]
@@ -84,10 +86,7 @@ where
         Sub<<<CS::Hash as EagerHash>::Core as BlockSizeUser>::BlockSize, Output = U32>,
 {
     /// The first step of pake-kem, where the initiator starts the protocol
-    pub fn start<R: RngCore + CryptoRng>(
-        input: &Input,
-        rng: &mut R,
-    ) -> Result<(Self, MessageOne<CS>)> {
+    pub fn start<R: CryptoRng>(input: &Input, rng: &mut R) -> Result<(Self, MessageOne<CS>)> {
         let (init_message, state) = CS::Pake::init(input, rng);
 
         Ok((Self(state), MessageOne { init_message }))
@@ -95,7 +94,7 @@ where
 
     /// The third step of pake-kem, where the initiator finishes its role in the protocol, with
     /// input from the second message created by the responder
-    pub fn finish<R: RngCore + CryptoRng>(
+    pub fn finish<R: CryptoRng>(
         self,
         message_two: &MessageTwo<CS>,
         rng: &mut R,
@@ -107,24 +106,21 @@ where
 
         // First, check the mac on ek
         let mut mac_verifier = Hmac::<CS::Hash>::new(&mac_key);
-        mac_verifier.update(&message_two.ek.as_bytes());
+        mac_verifier.update(&message_two.ek.to_bytes());
         mac_verifier.verify_slice(&message_two.ek_tag)?;
 
         // Encapsulate a shared key to the holder of the decapsulation key, receive the shared
         // secret `k_send` and the encapsulated form `ct`.
-        let (ct, k_send) = message_two
-            .ek
-            .encapsulate(rng)
-            .map_err(|_| PakeKemError::Deserialization)?;
+        let (ct, k_send) = message_two.ek.encapsulate_with_rng(rng);
 
         // Next, construct another mac
         let mut mac_builder = Hmac::<CS::Hash>::new(&mac_key);
-        mac_builder.update(&message_two.ek.as_bytes());
+        mac_builder.update(&message_two.ek.to_bytes());
         mac_builder.update(ct.as_slice());
         let mac = mac_builder.finalize().into_bytes();
 
         let mut hkdf = HkdfExtract::<CS::Hash>::new(None);
-        hkdf.input_ikm(&message_two.ek.as_bytes());
+        hkdf.input_ikm(&message_two.ek.to_bytes());
         hkdf.input_ikm(ct.as_slice());
         hkdf.input_ikm(&mac_key);
         hkdf.input_ikm(&session_key);
@@ -136,11 +132,18 @@ where
 }
 
 /// The main struct for the responder of the pake-kem protocol
-#[derive(Debug)]
 pub struct Responder<CS: CipherSuite> {
     pake_output: <CS::Pake as Pake>::Output,
-    dk: <CS::Kem as KemCore>::DecapsulationKey,
-    ek: <CS::Kem as KemCore>::EncapsulationKey,
+    dk: <CS::Kem as Kem>::DecapsulationKey,
+    ek: <CS::Kem as Kem>::EncapsulationKey,
+}
+
+impl<CS: CipherSuite> core::fmt::Debug for Responder<CS> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Responder")
+            .field("pake_output", &self.pake_output)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<CS: CipherSuite> Responder<CS>
@@ -150,7 +153,7 @@ where
 {
     /// The second step of pake-kem, where the responder starts its role in the protocol
     /// with input from the first message created by the initiator
-    pub fn start<R: RngCore + CryptoRng>(
+    pub fn start<R: CryptoRng>(
         input: &Input,
         message_one: &MessageOne<CS>,
         rng: &mut R,
@@ -163,10 +166,11 @@ where
         };
         let (mac_key, _) = pake_output_into_keys::<CS>(pake_output.as_bytes());
 
-        let (decapsulation_key, encapsulation_key) = CS::Kem::generate(rng);
+        let (decapsulation_key, encapsulation_key) = CS::Kem::generate_keypair_from_rng(rng);
 
-        let ek_bytes = encapsulation_key.as_bytes();
-        let ek_cloned = <CS::Kem as KemCore>::EncapsulationKey::from_bytes(&ek_bytes);
+        let ek_bytes = encapsulation_key.to_bytes();
+        let ek_cloned = <CS::Kem as Kem>::EncapsulationKey::new(&ek_bytes)
+            .map_err(|_| PakeKemError::Deserialization)?;
 
         let mut mac_builder = Hmac::<CS::Hash>::new(&mac_key);
         mac_builder.update(&ek_bytes);
@@ -192,17 +196,17 @@ where
         let (mac_key, session_key) = pake_output_into_keys::<CS>(self.pake_output.as_bytes());
 
         let mut mac_verifier = Hmac::<CS::Hash>::new(&mac_key);
-        mac_verifier.update(&self.ek.as_bytes());
+        mac_verifier.update(&self.ek.to_bytes());
         mac_verifier.update(message_three.ct.as_slice());
         mac_verifier.verify_slice(&message_three.ct_tag)?;
 
         let k_recv = self
             .dk
-            .decapsulate(&message_three.ct)
+            .try_decapsulate(&message_three.ct)
             .map_err(|_| PakeKemError::Deserialization)?;
 
         let mut hkdf = HkdfExtract::<CS::Hash>::new(None);
-        hkdf.input_ikm(&self.ek.as_bytes());
+        hkdf.input_ikm(&self.ek.to_bytes());
         hkdf.input_ikm(message_three.ct.as_slice());
         hkdf.input_ikm(&mac_key);
         hkdf.input_ikm(&session_key);
@@ -230,8 +234,8 @@ where
 impl<CS: CipherSuite> EncodedSizeUser for Initiator<CS> {
     type EncodedSize = <CS::Pake as EncodedSizeUser>::EncodedSize;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
-        Self(CS::Pake::from_bytes(enc))
+    fn from_bytes(enc: &Encoded<Self>) -> core::result::Result<Self, PakeKemError> {
+        Ok(Self(CS::Pake::from_bytes(enc)?))
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
@@ -241,56 +245,59 @@ impl<CS: CipherSuite> EncodedSizeUser for Initiator<CS> {
 
 impl<CS: CipherSuite> EncodedSizeUser for Responder<CS>
 where
+    CS::Kem: ml_kem::kem::FromSeed,
+    <CS::Kem as Kem>::DecapsulationKey: KeyExport + KeyInit,
+    <CS::Kem as Kem>::EncapsulationKey: KeyExport + TryKeyInit,
     // Concatenation clauses
-    <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize:
-        Add<<<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize>,
+    <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize:
+        Add<<<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize>,
     Sum<
-        <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize,
-        <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+        <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize,
+        <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
     >: ArraySize
         + Add<<<CS::Pake as Pake>::Output as EncodedSizeUser>::EncodedSize>
         + Sub<
-            <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize,
-            Output = <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize,
+            Output = <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
     Sum<
         Sum<
-            <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize,
-            <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize,
+            <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
         <<CS::Pake as Pake>::Output as EncodedSizeUser>::EncodedSize,
     >: ArraySize
         + Sub<
             Sum<
-                <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize,
-                <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+                <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize,
+                <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
             >,
             Output = <<CS::Pake as Pake>::Output as EncodedSizeUser>::EncodedSize,
         >,
 {
     type EncodedSize = Sum<
         Sum<
-            <<CS::Kem as KemCore>::DecapsulationKey as EncodedSizeUser>::EncodedSize,
-            <<CS::Kem as KemCore>::EncapsulationKey as EncodedSizeUser>::EncodedSize,
+            <<CS::Kem as Kem>::DecapsulationKey as KeySizeUser>::KeySize,
+            <<CS::Kem as Kem>::EncapsulationKey as KeySizeUser>::KeySize,
         >,
         <<CS::Pake as Pake>::Output as EncodedSizeUser>::EncodedSize,
     >;
 
-    fn from_bytes(enc: &Encoded<Self>) -> Self {
+    fn from_bytes(enc: &Encoded<Self>) -> core::result::Result<Self, PakeKemError> {
         let (enc, pake_output) = enc.split_ref();
         let (dk_bytes, ek_bytes) = enc.split_ref();
 
-        Self {
-            pake_output: <CS::Pake as Pake>::Output::from_bytes(pake_output),
-            dk: <CS::Kem as KemCore>::DecapsulationKey::from_bytes(dk_bytes),
-            ek: <CS::Kem as KemCore>::EncapsulationKey::from_bytes(ek_bytes),
-        }
+        Ok(Self {
+            pake_output: <CS::Pake as Pake>::Output::from_bytes(pake_output)?,
+            dk: <<CS::Kem as Kem>::DecapsulationKey as KeyInit>::new(dk_bytes),
+            ek: <<CS::Kem as Kem>::EncapsulationKey as TryKeyInit>::new(ek_bytes)
+                .map_err(|_| PakeKemError::Deserialization)?,
+        })
     }
 
     fn as_bytes(&self) -> Encoded<Self> {
-        self.dk
-            .as_bytes()
-            .concat(self.ek.as_bytes())
+        KeyExport::to_bytes(&self.dk)
+            .concat(KeyExport::to_bytes(&self.ek))
             .concat(self.pake_output.as_bytes())
     }
 }

--- a/src/tests/test_protocol.rs
+++ b/src/tests/test_protocol.rs
@@ -15,7 +15,7 @@ use crate::MessageOne;
 use crate::MessageThree;
 use crate::MessageTwo;
 use crate::Responder;
-use rand_core::OsRng;
+use rand_core::UnwrapErr;
 
 #[test]
 fn test_protocol() {
@@ -56,7 +56,7 @@ fn test_protocol() {
 }
 
 fn run_protocol(initiator_input: Input, responder_input: Input) -> Result<(), PakeKemError> {
-    let mut initiator_rng = OsRng;
+    let mut initiator_rng = UnwrapErr(getrandom::SysRng);
     let (initiator, message_one) =
         Initiator::<DefaultCipherSuite>::start(&initiator_input, &mut initiator_rng)
             .expect("Error with Initiator::start()");
@@ -64,20 +64,20 @@ fn run_protocol(initiator_input: Input, responder_input: Input) -> Result<(), Pa
 
     // Send message_one_bytes over the wire to the responder
 
-    let mut responder_rng = OsRng;
-    let message_one = MessageOne::from_bytes(&message_one_bytes);
+    let mut responder_rng = UnwrapErr(getrandom::SysRng);
+    let message_one = MessageOne::from_bytes(&message_one_bytes).unwrap();
     let (responder, message_two) =
         Responder::<DefaultCipherSuite>::start(&responder_input, &message_one, &mut responder_rng)
             .expect("Error with Responder::start()");
     let message_two_bytes = message_two.as_bytes();
     // Send message_two_bytes over the wire to the initiator
 
-    let message_two = MessageTwo::from_bytes(&message_two_bytes);
+    let message_two = MessageTwo::from_bytes(&message_two_bytes).unwrap();
     let (initiator_output, message_three) = initiator.finish(&message_two, &mut initiator_rng)?;
     let message_three_bytes = message_three.as_bytes();
     // Send message_three_bytes over the wire to the responder
 
-    let message_three = MessageThree::from_bytes(&message_three_bytes);
+    let message_three = MessageThree::from_bytes(&message_three_bytes).unwrap();
     let responder_output = responder.finish(&message_three)?;
 
     match initiator_output.0 == responder_output.0 {

--- a/src/tests/test_serialization.rs
+++ b/src/tests/test_serialization.rs
@@ -1,4 +1,4 @@
-use rand_core::OsRng;
+use rand_core::UnwrapErr;
 
 use crate::{
     DefaultCipherSuite, EncodedSizeUser, Initiator, Input, MessageOne, MessageThree, MessageTwo,
@@ -16,16 +16,20 @@ struct TestStructs {
 
 fn prepare_test_structs() -> TestStructs {
     let input = Input::new(b"password", b"initiator_id", b"responder_id");
-    let (initiator, message_one) = Initiator::<DefaultCipherSuite>::start(&input, &mut OsRng)
-        .expect("Error with Initiator::start()");
-    let initiator_clone = Initiator::from_bytes(&initiator.as_bytes());
+    let (initiator, message_one) =
+        Initiator::<DefaultCipherSuite>::start(&input, &mut UnwrapErr(getrandom::SysRng))
+            .expect("Error with Initiator::start()");
+    let initiator_clone = Initiator::from_bytes(&initiator.as_bytes()).unwrap();
 
-    let (responder, message_two) =
-        Responder::<DefaultCipherSuite>::start(&input, &message_one, &mut OsRng)
-            .expect("Error with Responder::start()");
+    let (responder, message_two) = Responder::<DefaultCipherSuite>::start(
+        &input,
+        &message_one,
+        &mut UnwrapErr(getrandom::SysRng),
+    )
+    .expect("Error with Responder::start()");
 
     let (_, message_three) = initiator_clone
-        .finish(&message_two, &mut OsRng)
+        .finish(&message_two, &mut UnwrapErr(getrandom::SysRng))
         .expect("Error with Initiator::finish()");
 
     TestStructs {
@@ -38,12 +42,12 @@ fn prepare_test_structs() -> TestStructs {
     }
 }
 
-fn corrupt_struct<T: EncodedSizeUser>(input: &T) -> T {
+fn corrupt_struct<T: EncodedSizeUser>(input: &T) -> Option<T> {
     let mut bad_bytes = input.as_bytes();
     for i in 0..bad_bytes.len() {
         bad_bytes[i] = bad_bytes[i].wrapping_add(1);
     }
-    T::from_bytes(&bad_bytes)
+    T::from_bytes(&bad_bytes).ok()
 }
 
 #[test]
@@ -51,23 +55,32 @@ fn test_normal_deserialization_for_structs() {
     let structs = prepare_test_structs();
     assert_eq!(
         structs.initiator.as_bytes(),
-        Initiator::<DefaultCipherSuite>::from_bytes(&structs.initiator.as_bytes()).as_bytes()
+        Initiator::<DefaultCipherSuite>::from_bytes(&structs.initiator.as_bytes())
+            .unwrap()
+            .as_bytes()
     );
     assert_eq!(
         structs.responder.as_bytes(),
-        Responder::<DefaultCipherSuite>::from_bytes(&structs.responder.as_bytes()).as_bytes()
+        Responder::<DefaultCipherSuite>::from_bytes(&structs.responder.as_bytes())
+            .unwrap()
+            .as_bytes()
     );
     assert_eq!(
         structs.message_one.as_bytes(),
-        MessageOne::<DefaultCipherSuite>::from_bytes(&structs.message_one.as_bytes()).as_bytes()
+        MessageOne::<DefaultCipherSuite>::from_bytes(&structs.message_one.as_bytes())
+            .unwrap()
+            .as_bytes()
     );
     assert_eq!(
         structs.message_two.as_bytes(),
-        MessageTwo::<DefaultCipherSuite>::from_bytes(&structs.message_two.as_bytes()).as_bytes()
+        MessageTwo::<DefaultCipherSuite>::from_bytes(&structs.message_two.as_bytes())
+            .unwrap()
+            .as_bytes()
     );
     assert_eq!(
         structs.message_three.as_bytes(),
         MessageThree::<DefaultCipherSuite>::from_bytes(&structs.message_three.as_bytes())
+            .unwrap()
             .as_bytes()
     );
 }
@@ -75,8 +88,13 @@ fn test_normal_deserialization_for_structs() {
 #[test]
 fn test_corrupt_initiator() {
     let structs = prepare_test_structs();
-    let corrupt_initiator = corrupt_struct::<Initiator<DefaultCipherSuite>>(&structs.initiator);
-    match corrupt_initiator.finish(&structs.message_two, &mut OsRng) {
+    let Some(corrupt_initiator) =
+        corrupt_struct::<Initiator<DefaultCipherSuite>>(&structs.initiator)
+    else {
+        // Deserialization correctly rejected corrupt data
+        return;
+    };
+    match corrupt_initiator.finish(&structs.message_two, &mut UnwrapErr(getrandom::SysRng)) {
         Err(PakeKemError::MacError(_)) => {}
         _ => panic!("Expected PakeKemError::MacError"),
     }
@@ -85,7 +103,12 @@ fn test_corrupt_initiator() {
 #[test]
 fn test_corrupt_responder() {
     let structs = prepare_test_structs();
-    let corrupt_responder = corrupt_struct::<Responder<DefaultCipherSuite>>(&structs.responder);
+    let Some(corrupt_responder) =
+        corrupt_struct::<Responder<DefaultCipherSuite>>(&structs.responder)
+    else {
+        // Deserialization correctly rejected corrupt data
+        return;
+    };
     match corrupt_responder.finish(&structs.message_three) {
         Err(PakeKemError::MacError(_)) => {}
         _ => panic!("Expected PakeKemError::MacError"),
@@ -95,26 +118,43 @@ fn test_corrupt_responder() {
 #[test]
 fn test_corrupt_message_one() {
     let structs = prepare_test_structs();
-    let corrupt_message_one =
-        corrupt_struct::<MessageOne<DefaultCipherSuite>>(&structs.message_one);
-    assert!(Responder::start(&structs.input, &corrupt_message_one, &mut OsRng).is_err());
+    let Some(corrupt_message_one) =
+        corrupt_struct::<MessageOne<DefaultCipherSuite>>(&structs.message_one)
+    else {
+        // Deserialization correctly rejected corrupt data
+        return;
+    };
+    assert!(Responder::start(
+        &structs.input,
+        &corrupt_message_one,
+        &mut UnwrapErr(getrandom::SysRng)
+    )
+    .is_err());
 }
 
 #[test]
 fn test_corrupt_message_two() {
     let structs = prepare_test_structs();
-    let corrupt_message_two =
-        corrupt_struct::<MessageTwo<DefaultCipherSuite>>(&structs.message_two);
+    let Some(corrupt_message_two) =
+        corrupt_struct::<MessageTwo<DefaultCipherSuite>>(&structs.message_two)
+    else {
+        // Deserialization correctly rejected corrupt data
+        return;
+    };
     assert!(structs
         .initiator
-        .finish(&corrupt_message_two, &mut OsRng)
+        .finish(&corrupt_message_two, &mut UnwrapErr(getrandom::SysRng))
         .is_err());
 }
 
 #[test]
 fn test_corrupt_message_three() {
     let structs = prepare_test_structs();
-    let corrupt_message_three =
-        corrupt_struct::<MessageThree<DefaultCipherSuite>>(&structs.message_three);
+    let Some(corrupt_message_three) =
+        corrupt_struct::<MessageThree<DefaultCipherSuite>>(&structs.message_three)
+    else {
+        // Deserialization correctly rejected corrupt data
+        return;
+    };
     assert!(structs.responder.finish(&corrupt_message_three).is_err());
 }


### PR DESCRIPTION

- Upgrade ml-kem to v0.3.0-rc.0 and related dependencies (rand_core 0.10, curve25519-dalek 5.0.0-pre.6, hkdf 0.13.0-rc.5, sha2 0.11.0-pre.4)
- Make `EncodedSizeUser::from_bytes` fallible
- Bump version to 0.1.0-pre.6